### PR TITLE
feat: Append and edit env values

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # :telescope: telescope-env.nvim
 
+Watch environment variables with telescope
+
 # Demo
 
 ![Demo](https://user-images.githubusercontent.com/10884422/148600299-b318fe61-93f5-45dd-bea3-31b19426390a.gif)
@@ -29,7 +31,15 @@ require('telescope').load_extension('env')
 # Usage
 `:Telescope env`
 
+### Key mappings
+| key     | Usage                                           |
+|---------|-------------------------------------------------|
+| `<cr>`  | append environment name to buffer               |
+| `<c-a>` | append environment value to buffer              |
+| `<c-e>` | edit environment value(for the current session) |
+
+
 # Roadmap :blue_car:
-- [ ] copy selected value when select an item in picker.
+- [x] copy selected value when select an item in picker.
 - [ ] use previews because some variables like `PATH` don't fit on screen.
 - [ ] ability to add temporary variables.

--- a/lua/telescope/_extensions/env.lua
+++ b/lua/telescope/_extensions/env.lua
@@ -1,82 +1,118 @@
-local pickers = require "telescope.pickers"
-local finders = require "telescope.finders"
-local actions = require "telescope.actions"
+local pickers = require("telescope.pickers")
+local finders = require("telescope.finders")
+local actions = require("telescope.actions")
+local action_state = require("telescope.actions.state")
+local make_entry = require("telescope.make_entry")
+
 local conf = require("telescope.config").values
-local entry_display = require('telescope.pickers.entry_display')
+local entry_display = require("telescope.pickers.entry_display")
 
 local function prepareEnvironmentVariables()
-  Items = {}
-  for key, value in pairs(vim.fn.environ()) do
-    table.insert(Items, {key, value})
-  end
-  return Items
+	Items = {}
+	for key, value in pairs(vim.fn.environ()) do
+		table.insert(Items, { key, value })
+	end
+	return Items
+end
+
+local function appendEnvironmentValue(prompt_bufnr)
+	local selection = action_state.get_selected_entry(prompt_bufnr)
+	actions.close(prompt_bufnr)
+	if selection.value == "" then
+		return
+	end
+	if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
+		vim.api.nvim_put({ selection.value[2] }, "b", true, true)
+	end
+end
+
+local function appendEnvironmentName(prompt_bufnr)
+	local selection = action_state.get_selected_entry(prompt_bufnr)
+	actions.close(prompt_bufnr)
+	if selection.value == "" then
+		return
+	end
+	if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
+		vim.api.nvim_put({ selection.value[1] }, "b", true, true)
+	end
+end
+
+local function editEnvironmentValue(prompt_bufnr)
+	local selection = action_state.get_selected_entry(prompt_bufnr)
+	actions.close(prompt_bufnr)
+	local value = vim.fn.input("[ENV] Enter new value: ", selection.value[2])
+	if value == "" then
+		return
+	end
+	print("Setting env %s=%s", selection.value[1], value)
+	-- Only works for the current session
+	vim.fn.setenv(selection.value[1], value)
 end
 
 local function showEnvironmentVariables(opts)
-  opts = opts or {}
-  pickers.new(opts, {
-    prompt_title = "Environment Variables",
-    finder = finders.new_table {
-      results = prepareEnvironmentVariables(),
-      entry_maker = function(entry)
-        local cols = vim.o.columns
-        local width = conf.width
-          or conf.layout_config.width
-          or conf.layout_config[conf.layout_strategy].width
-          or cols
-        local tel_win_width
-        if width > 1 then
-          tel_win_width = width
-        else
-          tel_win_width = math.floor(cols * width)
-        end
-        local desc_width = math.floor(cols * 0.05)
-        local command_width = 22
+	opts = opts or {}
+	pickers.new(opts, {
+		prompt_title = "Environment Variables",
+		finder = finders.new_table({
+			results = prepareEnvironmentVariables(),
+			entry_maker = function(entry)
+				local cols = vim.o.columns
+				local width = conf.width
+					or conf.layout_config.width
+					or conf.layout_config[conf.layout_strategy].width
+					or cols
+				local tel_win_width
+				if width > 1 then
+					tel_win_width = width
+				else
+					tel_win_width = math.floor(cols * width)
+				end
+				local desc_width = math.floor(cols * 0.05)
+				local command_width = 22
 
-        -- NOTE: the width calculating logic is not exact, but approx enough
-        local displayer = entry_display.create {
-          separator = " ▏",
-          items = {
-            { width = command_width },
-            { width = tel_win_width - desc_width - command_width },
-            { remaining = true },
-          },
-        }
+				-- NOTE: the width calculating logic is not exact, but approx enough
+				local displayer = entry_display.create({
+					separator = " ▏",
+					items = {
+						{ width = command_width },
+						{ width = tel_win_width - desc_width - command_width },
+						{ remaining = true },
+					},
+				})
 
-        local function make_display(ent)
-          return displayer
-          {
-            { entry[1] },
-            { entry[2] },
-          }
-        end
+				local function make_display(ent)
+					-- Concatinate multiline env values
+					local concat_value = entry[2]:gsub("\r?\n", " ")
+					return displayer({
+						{ entry[1] },
+						{ concat_value },
+					})
+				end
 
-        return
-        {
-          value = entry,
-          display =  make_display,
-          ordinal = string.format('%s %s', entry[1], entry[2])
-        }
-      end,
-
-    },
-    sorter = conf.generic_sorter(opts),
-    attach_mappings = function(prompt_bufnr, map)
-      actions.select_default:replace(function()
-        actions.close(prompt_bufnr)
-      end)
-      return true
-    end,
-  }):find()
+				return {
+					value = entry,
+					display = make_display,
+					ordinal = string.format("%s %s", entry[1], entry[2]),
+				}
+			end,
+		}),
+		sorter = conf.generic_sorter(opts),
+		attach_mappings = function(prompt_bufnr, map)
+			actions.select_default:replace(appendEnvironmentName)
+			map("i", "<c-a>", appendEnvironmentValue)
+			map("i", "<c-e>", editEnvironmentValue)
+			return true
+		end,
+	}):find()
 end
 
 local function run()
-  showEnvironmentVariables()
+	showEnvironmentVariables()
 end
 
-return require('telescope').register_extension {
-  exports = {
-    -- Default when to argument is given, i.e. :Telescope env
-    env = run,
-  }
-}
+return require("telescope").register_extension({
+	exports = {
+		-- Default when to argument is given, i.e. :Telescope env
+		env = run,
+	},
+})

--- a/lua/telescope/_extensions/env.lua
+++ b/lua/telescope/_extensions/env.lua
@@ -15,7 +15,7 @@ local function prepareEnvironmentVariables()
 end
 
 local function appendEnvironmentValue(prompt_bufnr)
-  local selection = action_state.get_selected_entry(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
   if selection.value == "" then
     return
@@ -26,7 +26,7 @@ local function appendEnvironmentValue(prompt_bufnr)
 end
 
 local function appendEnvironmentName(prompt_bufnr)
-  local selection = action_state.get_selected_entry(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
   if selection.value == "" then
     return
@@ -37,7 +37,7 @@ local function appendEnvironmentName(prompt_bufnr)
 end
 
 local function editEnvironmentValue(prompt_bufnr)
-  local selection = action_state.get_selected_entry(prompt_bufnr)
+  local selection = action_state.get_selected_entry()
   actions.close(prompt_bufnr)
   local value = vim.fn.input("[ENV] Enter new value: ", selection.value[2])
   if value == "" then

--- a/lua/telescope/_extensions/env.lua
+++ b/lua/telescope/_extensions/env.lua
@@ -8,111 +8,108 @@ local conf = require("telescope.config").values
 local entry_display = require("telescope.pickers.entry_display")
 
 local function prepareEnvironmentVariables()
-	Items = {}
-	for key, value in pairs(vim.fn.environ()) do
-		table.insert(Items, { key, value })
-	end
-	return Items
+  Items = {}
+  for key, value in pairs(vim.fn.environ()) do
+    table.insert(Items, { key, value })
+  end
+  return Items
 end
 
 local function appendEnvironmentValue(prompt_bufnr)
-	local selection = action_state.get_selected_entry(prompt_bufnr)
-	actions.close(prompt_bufnr)
-	if selection.value == "" then
-		return
-	end
-	if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
-		vim.api.nvim_put({ selection.value[2] }, "b", true, true)
-	end
+  local selection = action_state.get_selected_entry(prompt_bufnr)
+  actions.close(prompt_bufnr)
+  if selection.value == "" then
+    return
+  end
+  if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
+    vim.api.nvim_put({ selection.value[2] }, "b", true, true)
+  end
 end
 
 local function appendEnvironmentName(prompt_bufnr)
-	local selection = action_state.get_selected_entry(prompt_bufnr)
-	actions.close(prompt_bufnr)
-	if selection.value == "" then
-		return
-	end
-	if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
-		vim.api.nvim_put({ selection.value[1] }, "b", true, true)
-	end
+  local selection = action_state.get_selected_entry(prompt_bufnr)
+  actions.close(prompt_bufnr)
+  if selection.value == "" then
+    return
+  end
+  if vim.api.nvim_buf_get_option(vim.api.nvim_get_current_buf(), "modifiable") then
+    vim.api.nvim_put({ selection.value[1] }, "b", true, true)
+  end
 end
 
 local function editEnvironmentValue(prompt_bufnr)
-	local selection = action_state.get_selected_entry(prompt_bufnr)
-	actions.close(prompt_bufnr)
-	local value = vim.fn.input("[ENV] Enter new value: ", selection.value[2])
-	if value == "" then
-		return
-	end
-	print("Setting env %s=%s", selection.value[1], value)
-	-- Only works for the current session
-	vim.fn.setenv(selection.value[1], value)
+  local selection = action_state.get_selected_entry(prompt_bufnr)
+  actions.close(prompt_bufnr)
+  local value = vim.fn.input("[ENV] Enter new value: ", selection.value[2])
+  if value == "" then
+    return
+  end
+  print("Setting env %s=%s", selection.value[1], value)
+  -- Only works for the current session
+  vim.fn.setenv(selection.value[1], value)
 end
 
 local function showEnvironmentVariables(opts)
-	opts = opts or {}
-	pickers.new(opts, {
-		prompt_title = "Environment Variables",
-		finder = finders.new_table({
-			results = prepareEnvironmentVariables(),
-			entry_maker = function(entry)
-				local cols = vim.o.columns
-				local width = conf.width
-					or conf.layout_config.width
-					or conf.layout_config[conf.layout_strategy].width
-					or cols
-				local tel_win_width
-				if width > 1 then
-					tel_win_width = width
-				else
-					tel_win_width = math.floor(cols * width)
-				end
-				local desc_width = math.floor(cols * 0.05)
-				local command_width = 22
+  opts = opts or {}
+  pickers.new(opts, {
+    prompt_title = "Environment Variables",
+    finder = finders.new_table({
+      results = prepareEnvironmentVariables(),
+      entry_maker = function(entry)
+        local cols = vim.o.columns
+        local width = conf.width or conf.layout_config.width or conf.layout_config[conf.layout_strategy].width or cols
+        local tel_win_width
+        if width > 1 then
+          tel_win_width = width
+        else
+          tel_win_width = math.floor(cols * width)
+        end
+        local desc_width = math.floor(cols * 0.05)
+        local command_width = 22
 
-				-- NOTE: the width calculating logic is not exact, but approx enough
-				local displayer = entry_display.create({
-					separator = " ▏",
-					items = {
-						{ width = command_width },
-						{ width = tel_win_width - desc_width - command_width },
-						{ remaining = true },
-					},
-				})
+        -- NOTE: the width calculating logic is not exact, but approx enough
+        local displayer = entry_display.create({
+          separator = " ▏",
+          items = {
+            { width = command_width },
+            { width = tel_win_width - desc_width - command_width },
+            { remaining = true },
+          },
+        })
 
-				local function make_display(ent)
-					-- Concatinate multiline env values
-					local concat_value = entry[2]:gsub("\r?\n", " ")
-					return displayer({
-						{ entry[1] },
-						{ concat_value },
-					})
-				end
+        local function make_display(ent)
+          -- Concatinate multiline env values
+          local concat_value = entry[2]:gsub("\r?\n", " ")
+          return displayer({
+            { entry[1] },
+            { concat_value },
+          })
+        end
 
-				return {
-					value = entry,
-					display = make_display,
-					ordinal = string.format("%s %s", entry[1], entry[2]),
-				}
-			end,
-		}),
-		sorter = conf.generic_sorter(opts),
-		attach_mappings = function(prompt_bufnr, map)
-			actions.select_default:replace(appendEnvironmentName)
-			map("i", "<c-a>", appendEnvironmentValue)
-			map("i", "<c-e>", editEnvironmentValue)
-			return true
-		end,
-	}):find()
+        return {
+          value = entry,
+          display = make_display,
+          ordinal = string.format("%s %s", entry[1], entry[2]),
+        }
+      end,
+    }),
+    sorter = conf.generic_sorter(opts),
+    attach_mappings = function(prompt_bufnr, map)
+      actions.select_default:replace(appendEnvironmentName)
+      map("i", "<c-a>", appendEnvironmentValue)
+      map("i", "<c-e>", editEnvironmentValue)
+      return true
+    end,
+  }):find()
 end
 
 local function run()
-	showEnvironmentVariables()
+  showEnvironmentVariables()
 end
 
 return require("telescope").register_extension({
-	exports = {
-		-- Default when to argument is given, i.e. :Telescope env
-		env = run,
-	},
+  exports = {
+    -- Default when to argument is given, i.e. :Telescope env
+    env = run,
+  },
 })


### PR DESCRIPTION
This PR adds following functionality:

- append environment name to buffer( default behavior `<cr>`)
- append environment value to buffer( mapping `<c-a>`)
- edit environment value for the current session( mapping `<c-e>`), addressing https://github.com/LinArcX/telescope-env.nvim/issues/2
- fixes weird behavior (bug?) with multiline values

I've set default behavior to env name as in my experience you often need a name for all kinds of scripts. I've also formatted the code with StyLua.